### PR TITLE
builtin/envの実装

### DIFF
--- a/include/builtin.h
+++ b/include/builtin.h
@@ -6,7 +6,7 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/11 13:35:06 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/08/16 20:19:09 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/08/17 02:14:48 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,5 +16,6 @@
 # include "context.h"
 
 int	builtin_echo(t_context *ctx, char **args);
+int	builtin_env(t_context *ctx, char **args);
 
 #endif

--- a/include/variable.h
+++ b/include/variable.h
@@ -15,7 +15,7 @@
 
 # include "context.h"
 
-# define ATTR_EXPORTED 1
+# define VAR_ATTR_EXPORTED 1
 
 typedef struct s_variable
 {

--- a/libft/include/ft_list.h
+++ b/libft/include/ft_list.h
@@ -67,4 +67,6 @@ void	ft_list_remove_if(t_list *list, void *ref,
 			bool (*pred)(void *data, void *ref), void (*del)(void *data));
 void	ft_list_clear(t_list *list, void (*del)(void *));
 
+void	ft_list_iter(t_list *list, void (*f)(void *data));
+
 #endif

--- a/libft/list/list_iter.c
+++ b/libft/list/list_iter.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   list_iter.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/08/17 02:14:55 by kemizuki          #+#    #+#             */
+/*   Updated: 2023/08/17 02:14:55 by kemizuki         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_list.h"
+
+void	ft_list_iter(t_list *list, void (*f)(void *))
+{
+	t_node	*node;
+
+	if (list == NULL || f == NULL)
+		return ;
+	node = list->head;
+	while (node != NULL)
+	{
+		f(node->data);
+		node = node->next;
+	}
+}

--- a/libft/test/list.cpp
+++ b/libft/test/list.cpp
@@ -280,3 +280,28 @@ TEST(ft_list_clear, normal) {
 	ASSERT_TRUE(list->tail == nullptr);
 	ASSERT_TRUE(list->size == 0);
 }
+
+// iter
+TEST(ft_list_iter, normal) {
+	int data[3] = {42, 43, 44};
+	t_list *list;
+	t_list *copy;
+
+	list = ft_list_create();
+	for (int &i: data)
+		ft_list_push_back(list, &i);
+	auto copy_func = [](void *data) -> void * {
+		return new int(*(int *)data);
+	};
+	copy = ft_list_copy(list, copy_func, nullptr);
+	auto iter_func = [](void *data) -> void {
+		*(int *)data += 1;
+	};
+	ft_list_iter(copy, iter_func);
+	ASSERT_TRUE(*(int *)copy->head->data == 43);
+	ASSERT_TRUE(*(int *)copy->head->next->data == 44);
+	ASSERT_TRUE(*(int *)copy->head->next->next->data == 45);
+	ASSERT_TRUE(*(int *)copy->tail->data == 45);
+	ASSERT_TRUE(*(int *)copy->tail->prev->data == 44);
+	ASSERT_TRUE(*(int *)copy->tail->prev->prev->data == 43);
+}

--- a/src/builtin/builtin_internal.h
+++ b/src/builtin/builtin_internal.h
@@ -16,5 +16,7 @@
 # include "context.h"
 
 void	builtin_write_error(t_context *ctx, const char *cmd_name);
+void	builtin_stdout_error(t_context *ctx, const char *cmd_name);
+void	builtin_not_implemented(t_context *ctx, const char *cmd_name);
 
 #endif

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -1,0 +1,45 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/08/17 02:15:01 by kemizuki          #+#    #+#             */
+/*   Updated: 2023/08/17 02:15:02 by kemizuki         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtin.h"
+#include "builtin_internal.h"
+#include "libft.h"
+#include "variable.h"
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void	print_env(void *data)
+{
+	t_variable	*var;
+
+	var = (t_variable *)data;
+	if (var->attributes & VAR_ATTR_EXPORTED)
+		ft_putendl_fd(var->envstr, STDOUT_FILENO);
+}
+
+int	builtin_env(t_context *ctx, char **args)
+{
+	if (*args != NULL)
+	{
+		builtin_not_implemented(ctx, "env");
+		return (EXIT_FAILURE);
+	}
+	errno = 0;
+	ft_list_iter(ctx->variables, print_env);
+	if (errno)
+	{
+		builtin_stdout_error(ctx, "env");
+		return (EXIT_FAILURE);
+	}
+	return (EXIT_SUCCESS);
+}

--- a/src/builtin/error.c
+++ b/src/builtin/error.c
@@ -21,3 +21,15 @@ void	builtin_write_error(t_context *ctx, const char *cmd_name)
 	ft_dprintf(STDERR_FILENO, "%s: %s: write error: %s\n",
 		ctx->shell_name, cmd_name, strerror(errno));
 }
+
+void	builtin_stdout_error(t_context *ctx, const char *cmd_name)
+{
+	ft_dprintf(STDERR_FILENO, "%s: %s: stdout: %s\n",
+		ctx->shell_name, cmd_name, strerror(errno));
+}
+
+void	builtin_not_implemented(t_context *ctx, const char *cmd_name)
+{
+	ft_dprintf(STDERR_FILENO, "%s: %s: not implemented\n",
+		ctx->shell_name, cmd_name);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,10 +10,14 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 link_libraries(ft GTest::gtest GTest::gtest_main)
 
 file(GLOB VAR_SRC ${CMAKE_SOURCE_DIR}/src/variable/*.c)
+file(GLOB BUILTIN_SRC ${CMAKE_SOURCE_DIR}/src/builtin/*.c)
+
+# variable
 add_executable(test_variable variable.cpp ${VAR_SRC})
 target_include_directories(test_variable PUBLIC ${CMAKE_SOURCE_DIR}/src/variable)
 
-file(GLOB BUILTIN_SRC ${CMAKE_SOURCE_DIR}/src/builtin/*.c)
+# builtin
 add_executable(test_builtin_echo builtin_echo.cpp ${BUILTIN_SRC})
+add_executable(test_builtin_env builtin_env.cpp ${BUILTIN_SRC} ${VAR_SRC})
 
-gtest_discover_tests(test_builtin_echo test_variable)
+gtest_discover_tests(test_builtin_echo test_builtin_env test_variable)

--- a/test/builtin_env.cpp
+++ b/test/builtin_env.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "builtin.h"
+#include "variable.h"
+}
+
+TEST(builtin_env, normal) {
+	t_context ctx;
+
+	ctx.variables = ft_list_create();
+	setvar(&ctx, "NAME1", "VALUE1", 1);
+	setvar(&ctx, "NAME2", "VALUE2", 1);
+	// exportする
+	ft_list_iter(ctx.variables, [](void *data) {
+		auto *var = (t_variable *) data;
+		var->attributes |= VAR_ATTR_EXPORTED;
+	});
+	// NAME3はexportされていない
+	setvar(&ctx, "NAME3", "VALUE3", 1);
+
+	testing::internal::CaptureStdout();
+	char *args[] = {nullptr};
+	builtin_env(&ctx, args);
+	auto output = testing::internal::GetCapturedStdout();
+	ASSERT_STREQ(output.c_str(), "NAME1=VALUE1\nNAME2=VALUE2\n");
+}
+
+// 環境変数なし
+TEST(builtin_env, no_env) {
+	t_context ctx;
+
+	ctx.variables = ft_list_create();
+
+	testing::internal::CaptureStdout();
+	char *args[] = {nullptr};
+	builtin_env(&ctx, args);
+	auto output = testing::internal::GetCapturedStdout();
+	ASSERT_STREQ(output.c_str(), "");
+}


### PR DESCRIPTION
close #15 
引数がある場合は `minishell: env: not implemented` とエラーを出す.