### PR TITLE
refactor `export`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(minishell C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "-Wall -Wextra -Werror")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_compact_unwind")
 
 enable_testing()
 

--- a/include/variables.h
+++ b/include/variables.h
@@ -55,6 +55,7 @@ t_variable					*getvar(t_context *ctx, const char *name);
 int							setvar(t_context *ctx, const char *name,
 								const char *value, int overwrite);
 int							unsetvar(t_context *ctx, const char *name);
+int							exportvar(t_context *ctx, const char *name, const char *value);
 
 char						**get_environ(t_context *ctx);
 t_assignment_parse_status	parse_variable_assignment(

--- a/include/variables.h
+++ b/include/variables.h
@@ -6,7 +6,7 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 04:32:03 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/09/23 04:46:42 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/10/13 04:44:28 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,8 @@ t_variable					*getvar(t_context *ctx, const char *name);
 int							setvar(t_context *ctx, const char *name,
 								const char *value, int overwrite);
 int							unsetvar(t_context *ctx, const char *name);
-int							exportvar(t_context *ctx, const char *name, const char *value);
+int							exportvar(t_context *ctx, const char *name,
+								const char *value);
 
 char						**get_environ(t_context *ctx);
 t_assignment_parse_status	parse_variable_assignment(

--- a/src/builtins/export/export_each_arg.c
+++ b/src/builtins/export/export_each_arg.c
@@ -6,67 +6,41 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/18 19:18:02 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/08/18 19:30:30 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/10/13 04:36:14 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "builtins.h"
 #include "builtins/builtins_internal.h"
 #include "export_internal.h"
 #include "libft.h"
 #include "variables.h"
 #include <stdlib.h>
 
-static int	handle_only_identifier(
-	t_context *ctx,
-	t_parsed_variable_assignment result
-)
-{
-	t_variable	*var;
-
-	var = getvar(ctx, result.name);
-	if (var == NULL)
-	{
-		setvar(ctx, result.name, "", 0);
-		var = getvar(ctx, result.name);
-		var->attributes |= VAR_ATTR_NO_VALUE;
-	}
-	var->attributes |= VAR_ATTR_EXPORTED;
-	return (EXIT_SUCCESS);
-}
-
 static int	handle_assignment(
 	t_context *ctx,
-	t_parsed_variable_assignment result
-)
+	t_parsed_variable_assignment result)
 {
 	t_variable	*var;
 	char		*new_value;
 
 	var = getvar(ctx, result.name);
 	if (var == NULL || result.operation == OPERATION_SET)
-	{
-		setvar(ctx, result.name, result.value, 1);
-		var = getvar(ctx, result.name);
-		var->attributes |= VAR_ATTR_EXPORTED;
-		return (EXIT_SUCCESS);
-	}
+		return (exportvar(ctx, result.name, result.value));
 	if (result.operation == OPERATION_APPEND)
 	{
 		new_value = ft_strjoin(var->value, result.value);
 		if (new_value == NULL)
 			return (EXIT_FAILURE);
-		setvar(ctx, result.name, new_value, 1);
+		return (exportvar(ctx, result.name, new_value));
 	}
 	return (EXIT_SUCCESS);
 }
 
 static int	process_parse_result(
-		t_context *ctx,
-		const char *arg,
-		t_assignment_parse_status status,
-		t_parsed_variable_assignment result
-)
+	t_context *ctx,
+	const char *arg,
+	t_assignment_parse_status status,
+	t_parsed_variable_assignment result)
 {
 	if (status == ASSIGN_PARSE_IGNORE)
 		return (EXIT_SUCCESS);
@@ -76,7 +50,7 @@ static int	process_parse_result(
 		return (EXIT_FAILURE);
 	}
 	if (status == ASSIGN_PARSE_ONLY_IDENTIFIER)
-		return (handle_only_identifier(ctx, result));
+		return (exportvar(ctx, result.name, NULL));
 	return (handle_assignment(ctx, result));
 }
 

--- a/src/variables/exportvar.c
+++ b/src/variables/exportvar.c
@@ -1,0 +1,37 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exportvar.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/10/13 04:36:35 by kemizuki          #+#    #+#             */
+/*   Updated: 2023/10/13 04:36:37 by kemizuki         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "variables.h"
+#include <stdlib.h>
+
+// TODO: error handling when `getvar` or `setvar` fails
+// if variable already exists and `name == NULL`, only set attributes,
+// otherwise set appropriate value and attributes
+int	exportvar(t_context *ctx, const char *name, const char *value)
+{
+	t_variable	*var;
+
+	var = getvar(ctx, name);
+	if (var == NULL && value == NULL)
+	{
+		setvar(ctx, name, "", 1);
+		var = getvar(ctx, name);
+		var->attributes |= VAR_ATTR_NO_VALUE;
+	}
+	else if (value != NULL)
+	{
+		setvar(ctx, name, value, 1);
+		var = getvar(ctx, name);
+	}
+	var->attributes |= VAR_ATTR_EXPORTED;
+	return (EXIT_SUCCESS);
+}

--- a/tests/builtins_export.cpp
+++ b/tests/builtins_export.cpp
@@ -169,6 +169,26 @@ TEST_F(TestbuiltinsExport, ExportNameWithValue) {
 	);
 }
 
+// export NAME+=value
+TEST_F(TestbuiltinsExport, ExportNamePlusEqualWithValue) {
+	// capture
+	testing::internal::CaptureStdout();
+	auto status = run_export("NAME+=value");
+	EXPECT_EQ(status, EXIT_SUCCESS);
+	// attributeを確認
+	auto var = getvar(&ctx, "NAME");
+	EXPECT_TRUE(var->attributes & VAR_ATTR_EXPORTED);
+	EXPECT_FALSE(var->attributes & VAR_ATTR_NO_VALUE);
+
+	status = run_export(nullptr);
+	EXPECT_EQ(status, EXIT_SUCCESS);
+	EXPECT_EQ(testing::internal::GetCapturedStdout(),
+			  "declare -x NAME=\"namevalue\"\n" +
+			  DECLARED_EXPORTED +
+			  DECLARED_EXPORTED_NO_VALUE
+	);
+}
+
 // export EXPORTED+=value
 TEST_F(TestbuiltinsExport, ExportPlusEqualWithValue) {
 	// capture


### PR DESCRIPTION
`exportvar` を共通ロジックとして切り出して, `builtins_export` をリファクタした.
また, `export` にバグが修正し, テストケースを追加した.