### PR TITLE
fix `cd` to ignore options first

### DIFF
--- a/src/builtins/cd/cd.c
+++ b/src/builtins/cd/cd.c
@@ -6,13 +6,14 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 01:53:09 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/08/20 01:53:10 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/10/17 17:10:47 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 #include "builtins/builtins_internal.h"
 #include "cd_internal.h"
+#include "libft.h"
 #include "utils.h"
 #include <stdlib.h>
 
@@ -20,12 +21,12 @@ int	builtins_cd(t_context *ctx, const char **args)
 {
 	const char	*dirname;
 
-	if (*args == NULL)
+	args = ignore_options(args);
+	if (*args == NULL || ft_strcmp(*args, "-") == 0)
 	{
 		print_simple_error(ctx, "cd", ERR_NOT_IMPL);
 		return (EXIT_FAILURE);
 	}
-	args = ignore_options(args);
 	dirname = args[0];
 	if (change_directory(ctx, dirname) == 0)
 		return (bindpwd(ctx));


### PR DESCRIPTION
`cd -` や `cd --` は `not implemented` になる。

close #65 