### PR TITLE
use GNL in non-interactive shell

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -6,7 +6,7 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/16 02:57:58 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/10/16 02:58:15 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/10/17 18:21:20 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,8 +71,11 @@ static void	init_context(t_context *ctx, char **argv, char **envp)
 void	init_shell(t_context *ctx, char **argv, char **envp)
 {
 	init_context(ctx, argv, envp);
-	rl_outstream = stderr;
-	rl_event_hook = rl_hook_func;
+	if (ctx->is_interactive)
+	{
+		rl_outstream = stderr;
+		rl_event_hook = rl_hook_func;
+	}
 }
 
 void	init_loop(t_context *ctx)

--- a/src/main.c
+++ b/src/main.c
@@ -6,12 +6,13 @@
 /*   By: smatsuo <smatsuo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/16 22:28:27 by smatsuo           #+#    #+#             */
-/*   Updated: 2023/10/17 17:23:29 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/10/17 18:25:09 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ast.h"
 #include "context.h"
+#include "ft_stdio.h"
 #include "parser.h"
 #include <stdio.h>
 #include <readline/history.h>
@@ -36,6 +37,21 @@ static void	display_exit_message(t_context *ctx)
 	}
 }
 
+static char	*read_command_line(t_context *ctx)
+{
+	char	*line;
+
+	if (ctx->is_interactive)
+	{
+		line = readline(PROMPT);
+		if (line != NULL && *line != '\0')
+			add_history(line);
+	}
+	else
+		line = get_next_line(STDIN_FILENO);
+	return (line);
+}
+
 int	main(int argc, char **argv, char **envp)
 {
 	char		*line;
@@ -47,12 +63,11 @@ int	main(int argc, char **argv, char **envp)
 	while (true)
 	{
 		init_loop(&ctx);
-		line = readline(PROMPT);
+		line = read_command_line(&ctx);
 		if (line == NULL)
 			break ;
 		if (*line != '\0')
 		{
-			add_history(line);
 			ast = parse(line, &ctx);
 			if (ast != NULL)
 				execute_ast(&ctx, ast);


### PR DESCRIPTION
`./minishell << "echo hello"` で実行できるようにした。
`readline("")` だとコマンドが出力に出てしまうので、GNLを使う。

close #72 