### PR TITLE
improve cmake settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,15 @@ add_subdirectory(tests)
 # build readline
 include(ExternalProject)
 ExternalProject_Add(
-        gnu_readline
-        BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/readline/lib/libreadline.a
-        PREFIX ${CMAKE_BINARY_DIR}/readline
-        SOURCE_DIR ${CMAKE_SOURCE_DIR}/readline
-        CONFIGURE_COMMAND ${CMAKE_SOURCE_DIR}/readline/configure
-        -q --prefix=${CMAKE_BINARY_DIR}/readline --enable-shared=no
-        BUILD_COMMAND make
-        BUILD_IN_SOURCE 1
-        INSTALL_COMMAND make install
+    gnu_readline
+    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/readline/lib/libreadline.a
+    PREFIX ${CMAKE_BINARY_DIR}/readline
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/readline
+    CONFIGURE_COMMAND ${CMAKE_SOURCE_DIR}/readline/configure
+    -q --prefix=${CMAKE_BINARY_DIR}/readline --enable-shared=no
+    BUILD_COMMAND make
+    BUILD_IN_SOURCE 1
+    INSTALL_COMMAND make install
 )
 
 file(GLOB_RECURSE SRC src/*.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.14)
 project(minishell C)
 
 set(CMAKE_C_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(minishell C)
 
 set(CMAKE_C_STANDARD 17)
-set(CMAKE_C_FLAGS "-Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "-Wall -Wextra")
 
 enable_testing()
 

--- a/libft/CMakeLists.txt
+++ b/libft/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(libft C)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS "-Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "-Wall -Wextra")
 
 enable_testing()
 

--- a/libft/CMakeLists.txt
+++ b/libft/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.14)
 project(libft C)
 
 set(CMAKE_C_STANDARD 11)

--- a/libft/tests/CMakeLists.txt
+++ b/libft/tests/CMakeLists.txt
@@ -1,13 +1,20 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.14)
 project(libft_test)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
-find_package(GTest CONFIG REQUIRED)
+# Google Test v1.14.0
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG        f8d7d77c06936315286eb55f8de22cd23c188571
+)
+FetchContent_MakeAvailable(googletest)
 include(GoogleTest)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
-link_libraries(ft GTest::gtest GTest::gtest_main)
+link_libraries(ft gtest gtest_main)
 
 add_executable(test_list list.cpp)
 gtest_discover_tests(test_list)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,16 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.14)
 project(minishell_test)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(GTest CONFIG REQUIRED)
+# Google Test v1.14.0
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        f8d7d77c06936315286eb55f8de22cd23c188571
+)
+FetchContent_MakeAvailable(googletest)
 include(GoogleTest)
 
 # src/main.c 以外のファイル
@@ -18,7 +25,7 @@ foreach (TMP_PATH ${TMP})
 endforeach ()
 
 include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src ${DIR_LIST} ${CMAKE_BINARY_DIR}/readline/include)
-link_libraries(ft GTest::gtest GTest::gtest_main ${CMAKE_BINARY_DIR}/readline/lib/libreadline.a ncurses)
+link_libraries(ft gtest gtest_main ${CMAKE_BINARY_DIR}/readline/lib/libreadline.a ncurses)
 
 # SRCをオブジェクトライブラリにする
 add_library(src_obj OBJECT ${SRC})


### PR DESCRIPTION
- システムのGoogleTestに依存しないように
- `cmake_minimum_required` を調整