### PR TITLE
fix cd behavior for missing directories

### DIFF
--- a/src/builtins/cd/change_directory.c
+++ b/src/builtins/cd/change_directory.c
@@ -6,7 +6,7 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 17:20:07 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/11/13 17:07:22 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/11/13 17:17:22 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,6 +73,8 @@ int	change_directory(t_context *ctx, const char *newdir)
 	bool	is_canon_success;
 
 	is_canon_success = get_absolute_destination_path(ctx, newdir, &path);
+	if (path == NULL)
+		return (-1);
 	ret = chdir(path);
 	if (ret == 0)
 	{

--- a/src/builtins/cd/change_directory.c
+++ b/src/builtins/cd/change_directory.c
@@ -6,7 +6,7 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 17:20:07 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/09/23 04:44:13 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/11/13 17:07:22 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-static void	set_working_directory(t_context *ctx, char *path)
+static void	set_working_directory(t_context *ctx, const char *path)
 {
 	free(ctx->cwd);
 	ctx->cwd = ft_strdup(path);
@@ -46,6 +46,25 @@ bool	get_absolute_destination_path(t_context *ctx, const char *newdir,
 	return (true);
 }
 
+static int	retry_chdir(t_context *ctx, const char *newdir)
+{
+	int		ret;
+	char	*cwd_on_failure;
+
+	ret = chdir(newdir);
+	if (ret == 0)
+	{
+		cwd_on_failure = join_path(ctx->cwd, newdir);
+		if (cwd_on_failure == NULL)
+			return (-1);
+		sync_working_directory(ctx, "cd");
+		if (ctx->cwd == NULL)
+			set_working_directory(ctx, cwd_on_failure);
+		free(cwd_on_failure);
+	}
+	return (ret);
+}
+
 // return the value of chdir
 int	change_directory(t_context *ctx, const char *newdir)
 {
@@ -62,6 +81,8 @@ int	change_directory(t_context *ctx, const char *newdir)
 		if (is_canon_success || ctx->cwd == NULL)
 			set_working_directory(ctx, path);
 	}
+	else
+		ret = retry_chdir(ctx, newdir);
 	free(path);
 	return (ret);
 }

--- a/src/utils/directory.c
+++ b/src/utils/directory.c
@@ -6,7 +6,7 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/16 03:25:00 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/10/16 03:25:18 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/11/13 17:01:54 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,14 +16,16 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#define ERR_GETCWD "getcwd: cannot access parent directories"
+
 void	sync_working_directory(struct s_context *ctx, char *for_whom)
 {
 	free(ctx->cwd);
 	ctx->cwd = getcwd(NULL, 0);
 	if (ctx->cwd == NULL)
 		ft_dprintf(STDERR_FILENO,
-			"%s: getcwd: cannot access parent directories: %s\n",
-			for_whom, strerror(errno));
+			"%s: error retrieving current directory: %s: %s\n",
+			for_whom, ERR_GETCWD, strerror(errno));
 }
 
 // This function sets `ctx->cwd` and returns its copy


### PR DESCRIPTION
カレントディレクトリが消えた場合, 相対パスでの `cd` がすべて `No such file or directory` になっていた.
```bash
# こういう場合
mkdir -p /tmp/test; cd /tmp/test; rm -rf ../test
```

bash と同様, 引数そのままでリトライすることで `cd ..` 等で抜けられるようにした. また, エラーメッセージも合わせた.