### PR TITLE
properly set last exit status

### DIFF
--- a/src/exec/execute_ast.c
+++ b/src/exec/execute_ast.c
@@ -42,6 +42,8 @@ int	execute_ast(t_context *ctx, t_ast_node *ast)
 	if (info == NULL)
 		return (EXIT_FAILURE);
 	ret = execute_ast_impl(ctx, info, ast);
+	if (ctx->last_exit_status == EXIT_SUCCESS && ret != EXIT_SUCCESS)
+		ctx->last_exit_status = ret;
 	wait_children_and_set_exit_status(ctx, info->last_command_pid);
 	destroy_pipeline_info(info);
 	return (ret);


### PR DESCRIPTION
通常のコマンドはexitするのでステータスを取得できていたが, builtinではうまくいってなかった.

```bash
minishell$ cat > file
minishell: file: Permission denied
minishell$ echo $?
1
minishell$ echo > file
minishell: file: Permission denied
minishell$ echo $?
0
```