### PR TITLE
fix bug preventing cd command

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -42,7 +42,7 @@ void	print_simple_error(t_context *ctx, const char *cmd, const char *msg);
 // directory.c
 void	sync_working_directory(struct s_context *ctx, char *for_whom);
 char	*get_working_directory(struct s_context *ctx, char *for_whom);
-int		bindpwd(t_context *ctx);
+int		bindpwd(t_context *ctx, char *for_whom);
 
 // message.c
 void	display_exit_message(t_context *ctx);

--- a/src/builtins/cd/cd.c
+++ b/src/builtins/cd/cd.c
@@ -29,7 +29,7 @@ int	builtins_cd(t_context *ctx, const char **args)
 	}
 	dirname = args[0];
 	if (change_directory(ctx, dirname) == 0)
-		return (bindpwd(ctx));
+		return (bindpwd(ctx, "cd"));
 	perror_verbose(ctx, "cd", dirname);
 	return (EXIT_FAILURE);
 }

--- a/src/builtins/cd/change_directory.c
+++ b/src/builtins/cd/change_directory.c
@@ -54,9 +54,10 @@ static int	retry_chdir(t_context *ctx, const char *newdir)
 	ret = chdir(newdir);
 	if (ret == 0)
 	{
-		cwd_on_failure = join_path(ctx->cwd, newdir);
-		if (cwd_on_failure == NULL)
-			return (-1);
+		if (ctx->cwd == NULL)
+			cwd_on_failure = ft_strdup(newdir);
+		else
+			cwd_on_failure = join_path(ctx->cwd, newdir);
 		sync_working_directory(ctx, "cd");
 		if (ctx->cwd == NULL)
 			set_working_directory(ctx, cwd_on_failure);
@@ -73,10 +74,9 @@ int	change_directory(t_context *ctx, const char *newdir)
 	bool	is_canon_success;
 
 	is_canon_success = get_absolute_destination_path(ctx, newdir, &path);
-	if (path == NULL)
-		return (-1);
-	ret = chdir(path);
-	if (ret == 0)
+	if (path != NULL)
+		ret = chdir(path);
+	if (path != NULL && ret == 0)
 	{
 		if (!is_canon_success)
 			sync_working_directory(ctx, "cd");

--- a/src/init/init_shell.c
+++ b/src/init/init_shell.c
@@ -34,8 +34,10 @@ static int	set_default_values(t_context *ctx)
 	}
 	if (getenv("PWD") == NULL)
 	{
-		if (bindpwd(ctx) == EXIT_FAILURE || exportvar(ctx, "PWD", NULL) == -1)
-			return (EXIT_FAILURE);
+		if (bindpwd(ctx, "shell-init") == EXIT_SUCCESS) {
+			if (exportvar(ctx, "PWD", NULL) == -1)
+				return (EXIT_FAILURE);
+		}
 	}
 	return (EXIT_SUCCESS);
 }

--- a/src/init/init_shell.c
+++ b/src/init/init_shell.c
@@ -6,7 +6,7 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 01:03:34 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/12/03 00:50:08 by kemizuki         ###   ########.fr       */
+/*   Updated: 2023/12/09 09:24:57 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,8 @@ static int	set_default_values(t_context *ctx)
 	}
 	if (getenv("PWD") == NULL)
 	{
-		if (bindpwd(ctx, "shell-init") == EXIT_SUCCESS) {
+		if (bindpwd(ctx, "shell-init") == EXIT_SUCCESS)
+		{
 			if (exportvar(ctx, "PWD", NULL) == -1)
 				return (EXIT_FAILURE);
 		}

--- a/src/utils/directory.c
+++ b/src/utils/directory.c
@@ -40,12 +40,12 @@ char	*get_working_directory(struct s_context *ctx, char *for_whom)
 	return (ft_strdup(ctx->cwd));
 }
 
-int	bindpwd(t_context *ctx)
+int	bindpwd(t_context *ctx, char *for_whom)
 {
 	char	*dirname;
 	int		result;
 
-	dirname = get_working_directory(ctx, "cd");
+	dirname = get_working_directory(ctx, for_whom);
 	if (dirname == NULL)
 		return (EXIT_FAILURE);
 	if (setvar(ctx, "PWD", dirname, 1) == 0)


### PR DESCRIPTION
シェル初期化の時点でカレントディレクトリが存在しない場合に, 相対パスで `cd` ができなくなっていた.

```bash
bash$ mkdir -p /tmp/foo; cd /tmp/foo; rm -r ../foo
bash$ minishell
minishell$ cd ../
```

同じ状況で `cd .` するとエラーメッセージが2つ出るが, 直すべきか微妙.